### PR TITLE
Adding hint/warning log for use under a MultiChildrenderObjectElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 
 [Unreleased]: https://github.com/letsar/binder/compare/v1.0.1...HEAD
+[1.1.1]: https://github.com/letsar/binder/compare/releases/tag/v1.1.1
 [1.0.1]: https://github.com/letsar/binder/compare/releases/tag/v1.0.1
 [1.0.0]: https://github.com/letsar/binder/compare/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1] 
+### Added
+- An assertion for improper usages of Nil
+
 ## [1.0.1] 
 ### Added
 - A warning in the readme.

--- a/lib/src/nil.dart
+++ b/lib/src/nil.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:flutter/foundation.dart';
 
 /// A [Nil] instance, you can use in your layouts.
 const nil = Nil();

--- a/lib/src/nil.dart
+++ b/lib/src/nil.dart
@@ -17,6 +17,15 @@ class _NilElement extends Element {
   _NilElement(Nil widget) : super(widget);
 
   @override
+  void mount(Element? parent, dynamic newSlot) {
+    if (kDebugMode && parent is MultiChildRenderObjectElement) {
+      print('Warning message here');
+    }
+
+    super.mount(parent, newSlot);
+  }
+
+  @override
   bool get debugDoingBuild => false;
 
   @override

--- a/lib/src/nil.dart
+++ b/lib/src/nil.dart
@@ -19,13 +19,12 @@ class _NilElement extends Element {
 
   @override
   void mount(Element? parent, dynamic newSlot) {
-    if (kDebugMode && parent is MultiChildRenderObjectElement) {
-      print("""You are using Nil under a MultiChildRenderObjectElement.
+    assert(parent is MultiChildRenderObjectElement, """
+        You are using Nil under a MultiChildRenderObjectElement.
         This suggests a possibility that the Nil is not needed or is being used improperly.
         Make sure it can't be replaced with an inline conditional or
         omission of the target widget from a list.
         """);
-    }
 
     super.mount(parent, newSlot);
   }

--- a/lib/src/nil.dart
+++ b/lib/src/nil.dart
@@ -19,7 +19,7 @@ class _NilElement extends Element {
 
   @override
   void mount(Element? parent, dynamic newSlot) {
-    assert(parent is MultiChildRenderObjectElement, """
+    assert(parent is! MultiChildRenderObjectElement, """
         You are using Nil under a MultiChildRenderObjectElement.
         This suggests a possibility that the Nil is not needed or is being used improperly.
         Make sure it can't be replaced with an inline conditional or

--- a/lib/src/nil.dart
+++ b/lib/src/nil.dart
@@ -19,7 +19,11 @@ class _NilElement extends Element {
   @override
   void mount(Element? parent, dynamic newSlot) {
     if (kDebugMode && parent is MultiChildRenderObjectElement) {
-      print('Warning message here');
+      print("""You are using Nil under a MultiChildRenderObjectElement.
+        This suggests a possibility that the Nil is not needed or is being used improperly.
+        Make sure it can't be replaced with an inline conditional or
+        omission of the target widget from a list.
+        """);
     }
 
     super.mount(parent, newSlot);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nil
 description: A simple widget to add in the widget tree when you want to show nothing, with minimal impact on performance.
-version: 1.0.1
+version: 1.1.1
 homepage: https://github.com/letsar/nil
 
 environment:

--- a/test/nil_test.dart
+++ b/test/nil_test.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/nil_test.dart
+++ b/test/nil_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,4 +11,21 @@ void main() {
       Builder(builder: (_) => nil),
     );
   });
+
+  testWidgets(
+    'should throw if nil is used under a MultiChildRenderObjectElement',
+    (tester) async {
+      await tester.pumpWidget(
+        Column(
+          children: const [
+            nil,
+          ],
+        ),
+      );
+      expect(
+        tester.takeException(),
+        isAssertionError,
+      );
+    },
+  );
 }


### PR DESCRIPTION
Adds error when Nil is used "improperly"